### PR TITLE
fix responder after upgrading to L5

### DIFF
--- a/src/Vinelab/Api/Responder.php
+++ b/src/Vinelab/Api/Responder.php
@@ -28,25 +28,26 @@ class Responder
      */
     public function respond($response, $status, $headers, $options)
     {
-        // Default is JSON
         switch ($this->getRequestFormat()) {
-            case 'html':
+            case 'html' :
+            case 'text/html' :
                 return Response::make($response, $status, $headers, $options)
                     ->header('Content-Type', 'text/html');
             default :
+                // whether 'Content-Type' is NULL or equal to anything such as 'application/json' response will be JSON
                 return Response::json($response, $status, $headers, $options);
         }
 
     }
 
     /**
-     * Get url format from the content type header property
+     * Get request format from the content type header property
      *
-     * @return mixed
+     * @return string
      */
     public function getRequestFormat()
     {
-        return $this->request->format();
+        return $this->request->header('Content-Type');
     }
 
 }


### PR DESCRIPTION
the `Request::format()` is not returning the correct `Content-Type`
replace it with `Request::header('Content-Type')` to return the
correct `Content-Type` of the request
